### PR TITLE
feat: build for arm64 in addition to x86

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,9 @@
 env:
   APP_NAME: ${BUILDKITE_PIPELINE_SLUG}
   IMAGE_REPO: ghcr.io/theopenlane/${APP_NAME}
+  IMAGE_TAG: ${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:8}
   SONAR_HOST: "https://sonarcloud.io"
+
 steps:
   - group: ":test_tube: Tests"
     key: "tests"
@@ -93,6 +95,11 @@ steps:
         key: "docker-pr-build"
         cancel_on_build_failing: true
         if: build.branch != "main" && build.tag == null
+        matrix:
+          setup:
+            platform:
+              - amd64
+              - arm64
         commands: |
           #!/bin/bash
           ls
@@ -102,9 +109,11 @@ steps:
                 - "${IMAGE_REPO}"
               extra_tags:
                 - "${IMAGE_TAG}"
-          - theopenlane/container-build#v1.0.0:
+              tag_prefix: "{{matrix.platform}}-"
+          - theopenlane/container-build#v1.1.0:
               dockerfile: docker/Dockerfile
               push: false
+              platforms: linux/{{matrix.platform}}
               build-args:
                 - NAME=${APP_NAME}
           - equinixmetal-buildkite/trivy#v1.18.5:
@@ -115,6 +124,11 @@ steps:
       - label: ":docker: docker build and publish"
         key: "docker-build"
         cancel_on_build_failing: true
+        matrix:
+          setup:
+            platform:
+              - amd64
+              - arm64
         if: build.branch == "main"
         commands: |
           #!/bin/bash
@@ -129,9 +143,12 @@ steps:
                 - "${IMAGE_REPO}"
               extra_tags:
                 - "${IMAGE_TAG}"
-          - theopenlane/container-build#v1.0.0:
+                - latest
+              tag_prefix: "{{matrix.platform}}-"
+          - theopenlane/container-build#v1.1.0:
               dockerfile: docker/Dockerfile
               push: true
+              platforms: linux/{{matrix.platform}}
               build-args:
                 - NAME=${APP_NAME}
           - equinixmetal-buildkite/trivy#v1.18.5:
@@ -142,6 +159,11 @@ steps:
       - label: ":docker: docker build and publish"
         key: "docker-build-and-tag"
         if: build.tag != null
+        matrix:
+          setup:
+            platform:
+              - amd64
+              - arm64
         commands: |
           #!/bin/bash
         plugins:
@@ -154,9 +176,11 @@ steps:
                 - "${IMAGE_REPO}"
               extra_tags:
                 - "${BUILDKITE_TAG}"
-          - theopenlane/container-build#v1.0.0:
+              tag_prefix: "{{matrix.platform}}-"
+          - theopenlane/container-build#v1.1.0:
               dockerfile: docker/Dockerfile
               push: true
+              platforms: linux/{{matrix.platform}}
               build-args:
                 - NAME=${APP_NAME}
           - equinixmetal-buildkite/trivy#v1.18.5:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,12 @@
-FROM golang:1.23.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23.1 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /go/src/app
 COPY . .
 
-RUN CGO_ENABLED=1 GOOS=linux go build -o /go/bin/riverboat -a -ldflags '-linkmode external -extldflags "-static"' .
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/riverboat .
 
 FROM gcr.io/distroless/static:nonroot
 


### PR DESCRIPTION
- Updates the docker file to support multi platform builds
- Adds a build matrix to the main builds to push both amd64 and arm64 images
- Adds `latest` tag (prefixed with the platform)

Test run: 
![image](https://github.com/user-attachments/assets/c16c2ee9-0d8d-44a6-9faf-c06c7153dac5)
