### PR TITLE
Custom domain job scaffolding

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -3,15 +3,24 @@ river:
     databaseHost: postgres://postgres:password@0.0.0.0:5432/jobs?sslmode=disable
     queues: null
     workers:
+        createCustomDomainWorker:
+            Config:
+                cloudflareApiKey: ""
         databaseWorker:
             config:
                 baseUrl: http://localhost:1337
                 debug: false
                 enabled: true
                 endpoint: query
+        deleteCustomDomainWorker:
+            Config:
+                cloudflareApiKey: ""
         emailWorker:
             config:
                 devMode: true
                 fromEmail: no-reply@example.com
                 testDir: fixtures/email
                 token: ""
+        validateCustomDomainWorker:
+            Config:
+                cloudflareApiKey: ""

--- a/configgen/api-docs.md
+++ b/configgen/api-docs.md
@@ -40,6 +40,9 @@ Workers that will be enabled on the server
 |----|----|-----------|--------|
 |[**emailWorker**](#riverworkersemailworker)|`object`|EmailWorker is a worker to send emails using the resend email provider the config defaults to dev mode, which will write the email to a file using the mock provider a token is required to send emails using the actual resend provider<br/>||
 |[**databaseWorker**](#riverworkersdatabaseworker)|`object`|DatabaseWorker is a worker to create a dedicated database for an organization<br/>||
+|[**createCustomDomainWorker**](#riverworkerscreatecustomdomainworker)|`object`|CreateCustomDomainWorker creates a custom hostname in cloudflare, and creates and updates the records in our system<br/>||
+|[**validateCustomDomainWorker**](#riverworkersvalidatecustomdomainworker)|`object`|ValidateCustomDomainWorker checks cloudflare custom domain(s), and updates the status in our system<br/>||
+|[**deleteCustomDomainWorker**](#riverworkersdeletecustomdomainworker)|`object`|DeleteCustomDomainWorker delete the custom hostname from cloudflare and updates the records in our system<br/>||
 
 **Additional Properties:** not allowed  
 <a name="riverworkersemailworker"></a>
@@ -95,6 +98,84 @@ DatabaseWorker is a worker to create a dedicated database for an organization
 |**baseUrl**|`string`|Base URL for the dbx service<br/>||
 |**endpoint**|`string`|Endpoint for the graphql api<br/>||
 |**debug**|`boolean`|Enable debug mode<br/>||
+
+**Additional Properties:** not allowed  
+<a name="riverworkerscreatecustomdomainworker"></a>
+#### river\.workers\.createCustomDomainWorker: object
+
+CreateCustomDomainWorker creates a custom hostname in cloudflare, and creates and updates the records in our system
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|[**Config**](#riverworkerscreatecustomdomainworkerconfig)|`object`|CreateCustomDomainConfig contains the configuration for the worker<br/>||
+
+**Additional Properties:** not allowed  
+<a name="riverworkerscreatecustomdomainworkerconfig"></a>
+##### river\.workers\.createCustomDomainWorker\.Config: object
+
+CreateCustomDomainConfig contains the configuration for the worker
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**cloudflareApiKey**|`string`|||
+
+**Additional Properties:** not allowed  
+<a name="riverworkersvalidatecustomdomainworker"></a>
+#### river\.workers\.validateCustomDomainWorker: object
+
+ValidateCustomDomainWorker checks cloudflare custom domain(s), and updates the status in our system
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|[**Config**](#riverworkersvalidatecustomdomainworkerconfig)|`object`|ValidateCustomDomainConfig contains the configuration for the worker<br/>||
+
+**Additional Properties:** not allowed  
+<a name="riverworkersvalidatecustomdomainworkerconfig"></a>
+##### river\.workers\.validateCustomDomainWorker\.Config: object
+
+ValidateCustomDomainConfig contains the configuration for the worker
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**cloudflareApiKey**|`string`|||
+
+**Additional Properties:** not allowed  
+<a name="riverworkersdeletecustomdomainworker"></a>
+#### river\.workers\.deleteCustomDomainWorker: object
+
+DeleteCustomDomainWorker delete the custom hostname from cloudflare and updates the records in our system
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|[**Config**](#riverworkersdeletecustomdomainworkerconfig)|`object`|DeleteCustomDomainConfig contains the configuration for the example worker<br/>||
+
+**Additional Properties:** not allowed  
+<a name="riverworkersdeletecustomdomainworkerconfig"></a>
+##### river\.workers\.deleteCustomDomainWorker\.Config: object
+
+DeleteCustomDomainConfig contains the configuration for the example worker
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**cloudflareApiKey**|`string`|||
 
 **Additional Properties:** not allowed  
 

--- a/configgen/riverboat.config.json
+++ b/configgen/riverboat.config.json
@@ -30,6 +30,26 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "jobs.CreateCustomDomainConfig": {
+      "properties": {
+        "cloudflareApiKey": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "CreateCustomDomainConfig contains the configuration for the worker"
+    },
+    "jobs.CreateCustomDomainWorker": {
+      "properties": {
+        "Config": {
+          "$ref": "#/$defs/jobs.CreateCustomDomainConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "CreateCustomDomainWorker creates a custom hostname in cloudflare, and creates and updates the records in our system"
+    },
     "jobs.DatabaseWorker": {
       "properties": {
         "config": {
@@ -40,6 +60,26 @@
       "additionalProperties": false,
       "type": "object",
       "description": "DatabaseWorker is a worker to create a dedicated database for an organization"
+    },
+    "jobs.DeleteCustomDomainConfig": {
+      "properties": {
+        "cloudflareApiKey": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "DeleteCustomDomainConfig contains the configuration for the example worker"
+    },
+    "jobs.DeleteCustomDomainWorker": {
+      "properties": {
+        "Config": {
+          "$ref": "#/$defs/jobs.DeleteCustomDomainConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "DeleteCustomDomainWorker delete the custom hostname from cloudflare and updates the records in our system"
     },
     "jobs.EmailConfig": {
       "properties": {
@@ -74,6 +114,26 @@
       "additionalProperties": false,
       "type": "object",
       "description": "EmailWorker is a worker to send emails using the resend email provider the config defaults to dev mode, which will write the email to a file using the mock provider a token is required to send emails using the actual resend provider"
+    },
+    "jobs.ValidateCustomDomainConfig": {
+      "properties": {
+        "cloudflareApiKey": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ValidateCustomDomainConfig contains the configuration for the worker"
+    },
+    "jobs.ValidateCustomDomainWorker": {
+      "properties": {
+        "Config": {
+          "$ref": "#/$defs/jobs.ValidateCustomDomainConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "ValidateCustomDomainWorker checks cloudflare custom domain(s), and updates the status in our system"
     },
     "river.Config": {
       "properties": {
@@ -118,6 +178,18 @@
         "databaseWorker": {
           "$ref": "#/$defs/jobs.DatabaseWorker",
           "description": "DatabaseWorker configuration for creating databases using openlane/dbx"
+        },
+        "createCustomDomainWorker": {
+          "$ref": "#/$defs/jobs.CreateCustomDomainWorker",
+          "description": "CreateCustomDomainWorker configuration for creating custom domains"
+        },
+        "validateCustomDomainWorker": {
+          "$ref": "#/$defs/jobs.ValidateCustomDomainWorker",
+          "description": "ValidateCustomDomainWorker configuration for validating custom domains"
+        },
+        "deleteCustomDomainWorker": {
+          "$ref": "#/$defs/jobs.DeleteCustomDomainWorker",
+          "description": "DeleteCustomDomainWorker configuration for deleting custom domains"
         }
       },
       "additionalProperties": false,

--- a/internal/river/config.go
+++ b/internal/river/config.go
@@ -39,5 +39,14 @@ type Workers struct {
 	// DatabaseWorker configuration for creating databases using openlane/dbx
 	DatabaseWorker jobs.DatabaseWorker `koanf:"databaseWorker" json:"databaseWorker"`
 
+	// CreateCustomDomainWorker configuration for creating custom domains
+	CreateCustomDomainWorker jobs.CreateCustomDomainWorker `koanf:"createCustomDomainWorker" json:"createCustomDomainWorker"`
+
+	// ValidateCustomDomainWorker configuration for validating custom domains
+	ValidateCustomDomainWorker jobs.ValidateCustomDomainWorker `koanf:"validateCustomDomainWorker" json:"validateCustomDomainWorker"`
+
+	// DeleteCustomDomainWorker configuration for deleting custom domains
+	DeleteCustomDomainWorker jobs.DeleteCustomDomainWorker `koanf:"deleteCustomDomainWorker" json:"deleteCustomDomainWorker"`
+
 	// add more workers here
 }

--- a/internal/river/workers.go
+++ b/internal/river/workers.go
@@ -25,6 +25,27 @@ func createWorkers(c Workers) (*river.Workers, error) {
 		return nil, err
 	}
 
+	if err := river.AddWorkerSafely(workers, &jobs.CreateCustomDomainWorker{
+		Config: c.CreateCustomDomainWorker.Config,
+	},
+	); err != nil {
+		return nil, err
+	}
+
+	if err := river.AddWorkerSafely(workers, &jobs.ValidateCustomDomainWorker{
+		Config: c.ValidateCustomDomainWorker.Config,
+	},
+	); err != nil {
+		return nil, err
+	}
+
+	if err := river.AddWorkerSafely(workers, &jobs.DeleteCustomDomainWorker{
+		Config: c.DeleteCustomDomainWorker.Config,
+	},
+	); err != nil {
+		return nil, err
+	}
+
 	// add more workers here
 
 	return workers, nil

--- a/pkg/jobs/create_custom_domain.go
+++ b/pkg/jobs/create_custom_domain.go
@@ -1,0 +1,39 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	"github.com/rs/zerolog/log"
+)
+
+// CreateCustomDomainArgs for the worker to process the custom domain
+type CreateCustomDomainArgs struct {
+	// ID of the custom domain in our system
+	CustomDomainID string `json:"custom_domain_id"`
+}
+
+// Kind satisfies the river.Job interface
+func (CreateCustomDomainArgs) Kind() string { return "create_custom_domain" }
+
+// CreateCustomDomainWorker creates a custom hostname in cloudflare, and
+// creates and updates the records in our system
+type CreateCustomDomainWorker struct {
+	river.WorkerDefaults[CreateCustomDomainArgs]
+
+	Config CreateCustomDomainConfig
+}
+
+// CreateCustomDomainConfig contains the configuration for the worker
+type CreateCustomDomainConfig struct {
+	CloudflareAPIKey string `koanf:"cloudflareApiKey" json:"cloudflareApiKey" jsonschema:"required description=the cloudflare api key"`
+}
+
+// Work satisfies the river.Worker interface for the create custom domain worker
+// it creates a custom domain for an organization
+// todo(acookin): implement this
+func (w *CreateCustomDomainWorker) Work(ctx context.Context, job *river.Job[CreateCustomDomainArgs]) error {
+	log.Info().Str("custom_domain_id", job.Args.CustomDomainID).Msg("creating custom domain")
+
+	return nil
+}

--- a/pkg/jobs/create_custom_domain.go
+++ b/pkg/jobs/create_custom_domain.go
@@ -32,7 +32,7 @@ type CreateCustomDomainConfig struct {
 // Work satisfies the river.Worker interface for the create custom domain worker
 // it creates a custom domain for an organization
 // todo(acookin): implement this
-func (w *CreateCustomDomainWorker) Work(ctx context.Context, job *river.Job[CreateCustomDomainArgs]) error {
+func (w *CreateCustomDomainWorker) Work(_ context.Context, job *river.Job[CreateCustomDomainArgs]) error {
 	log.Info().Str("custom_domain_id", job.Args.CustomDomainID).Msg("creating custom domain")
 
 	return nil

--- a/pkg/jobs/create_custom_domain_test.go
+++ b/pkg/jobs/create_custom_domain_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/riverqueue/river"
 	"github.com/stretchr/testify/require"
+
 	"github.com/theopenlane/riverboat/pkg/jobs"
 )
 

--- a/pkg/jobs/create_custom_domain_test.go
+++ b/pkg/jobs/create_custom_domain_test.go
@@ -1,0 +1,25 @@
+package jobs_test
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+	"github.com/theopenlane/riverboat/pkg/jobs"
+)
+
+func (suite *TestSuite) TestCreateCustomDomainWorker() {
+	t := suite.T()
+	worker := &jobs.CreateCustomDomainWorker{
+		Config: jobs.CreateCustomDomainConfig{
+			CloudflareAPIKey: "test",
+		},
+	}
+	ctx := context.Background()
+
+	err := worker.Work(ctx, &river.Job[jobs.CreateCustomDomainArgs]{Args: jobs.CreateCustomDomainArgs{
+		CustomDomainID: "test",
+	}})
+
+	require.NoError(t, err)
+}

--- a/pkg/jobs/delete_custom_domain.go
+++ b/pkg/jobs/delete_custom_domain.go
@@ -1,0 +1,39 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	"github.com/rs/zerolog/log"
+)
+
+// DeleteCustomDomainArgs for the worker to process the custom domain
+type DeleteCustomDomainArgs struct {
+	// ID of the custom domain in our system
+	CustomDomainID string `json:"custom_domain_id"`
+}
+
+// Kind satisfies the river.Job interface
+func (DeleteCustomDomainArgs) Kind() string { return "delete_custom_domain" }
+
+// DeleteCustomDomainWorker delete the custom hostname from cloudflare and
+// updates the records in our system
+type DeleteCustomDomainWorker struct {
+	river.WorkerDefaults[DeleteCustomDomainArgs]
+
+	Config DeleteCustomDomainConfig
+}
+
+// DeleteCustomDomainConfig contains the configuration for the example worker
+type DeleteCustomDomainConfig struct {
+	CloudflareAPIKey string `koanf:"cloudflareApiKey" json:"cloudflareApiKey" jsonschema:"required description=the cloudflare api key"`
+}
+
+// Work satisfies the river.Worker interface for the delete custom domain worker
+// it deletes a custom domain for an organization
+// todo(acookin): implement this
+func (w *DeleteCustomDomainWorker) Work(ctx context.Context, job *river.Job[DeleteCustomDomainArgs]) error {
+	log.Info().Str("custom_domain_id", job.Args.CustomDomainID).Msg("creating custom domain")
+
+	return nil
+}

--- a/pkg/jobs/delete_custom_domain.go
+++ b/pkg/jobs/delete_custom_domain.go
@@ -32,7 +32,7 @@ type DeleteCustomDomainConfig struct {
 // Work satisfies the river.Worker interface for the delete custom domain worker
 // it deletes a custom domain for an organization
 // todo(acookin): implement this
-func (w *DeleteCustomDomainWorker) Work(ctx context.Context, job *river.Job[DeleteCustomDomainArgs]) error {
+func (w *DeleteCustomDomainWorker) Work(_ context.Context, job *river.Job[DeleteCustomDomainArgs]) error {
 	log.Info().Str("custom_domain_id", job.Args.CustomDomainID).Msg("creating custom domain")
 
 	return nil

--- a/pkg/jobs/delete_custom_domain_test.go
+++ b/pkg/jobs/delete_custom_domain_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/riverqueue/river"
 	"github.com/stretchr/testify/require"
+
 	"github.com/theopenlane/riverboat/pkg/jobs"
 )
 

--- a/pkg/jobs/delete_custom_domain_test.go
+++ b/pkg/jobs/delete_custom_domain_test.go
@@ -1,0 +1,25 @@
+package jobs_test
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+	"github.com/theopenlane/riverboat/pkg/jobs"
+)
+
+func (suite *TestSuite) TestDeleteCustomDomainWorker() {
+	t := suite.T()
+	worker := &jobs.DeleteCustomDomainWorker{
+		Config: jobs.DeleteCustomDomainConfig{
+			CloudflareAPIKey: "test",
+		},
+	}
+	ctx := context.Background()
+
+	err := worker.Work(ctx, &river.Job[jobs.DeleteCustomDomainArgs]{Args: jobs.DeleteCustomDomainArgs{
+		CustomDomainID: "test",
+	}})
+
+	require.NoError(t, err)
+}

--- a/pkg/jobs/validate_custom_domain.go
+++ b/pkg/jobs/validate_custom_domain.go
@@ -33,7 +33,7 @@ type ValidateCustomDomainConfig struct {
 // Work satisfies the river.Worker interface for the validate custom domain worker
 // it validates a custom domain for an organization
 // todo(acookin): implement this
-func (w *ValidateCustomDomainWorker) Work(ctx context.Context, job *river.Job[ValidateCustomDomainArgs]) error {
+func (w *ValidateCustomDomainWorker) Work(_ context.Context, job *river.Job[ValidateCustomDomainArgs]) error {
 	log.Info().Str("custom_domain_id", job.Args.CustomDomainID).Msg("creating custom domain")
 
 	return nil

--- a/pkg/jobs/validate_custom_domain.go
+++ b/pkg/jobs/validate_custom_domain.go
@@ -1,0 +1,40 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	"github.com/rs/zerolog/log"
+)
+
+// ValidateCustomDomainArgs for the worker to process the custom domain
+type ValidateCustomDomainArgs struct {
+	// ID of the custom domain in our system this is not required. When not
+	// passed, will validate all custom domains for the organization
+	CustomDomainID string `json:"custom_domain_id"`
+}
+
+// Kind satisfies the river.Job interface
+func (ValidateCustomDomainArgs) Kind() string { return "validate_custom_domain" }
+
+// ValidateCustomDomainWorker checks cloudflare custom domain(s), and updates
+// the status in our system
+type ValidateCustomDomainWorker struct {
+	river.WorkerDefaults[ValidateCustomDomainArgs]
+
+	Config ValidateCustomDomainConfig
+}
+
+// ValidateCustomDomainConfig contains the configuration for the worker
+type ValidateCustomDomainConfig struct {
+	CloudflareAPIKey string `koanf:"cloudflareApiKey" json:"cloudflareApiKey" jsonschema:"required description=the cloudflare api key"`
+}
+
+// Work satisfies the river.Worker interface for the validate custom domain worker
+// it validates a custom domain for an organization
+// todo(acookin): implement this
+func (w *ValidateCustomDomainWorker) Work(ctx context.Context, job *river.Job[ValidateCustomDomainArgs]) error {
+	log.Info().Str("custom_domain_id", job.Args.CustomDomainID).Msg("creating custom domain")
+
+	return nil
+}

--- a/pkg/jobs/validate_custom_domain_test.go
+++ b/pkg/jobs/validate_custom_domain_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/riverqueue/river"
 	"github.com/stretchr/testify/require"
+
 	"github.com/theopenlane/riverboat/pkg/jobs"
 )
 

--- a/pkg/jobs/validate_custom_domain_test.go
+++ b/pkg/jobs/validate_custom_domain_test.go
@@ -1,0 +1,25 @@
+package jobs_test
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+	"github.com/theopenlane/riverboat/pkg/jobs"
+)
+
+func (suite *TestSuite) TestValidateCustomDomainWorker() {
+	t := suite.T()
+	worker := &jobs.ValidateCustomDomainWorker{
+		Config: jobs.ValidateCustomDomainConfig{
+			CloudflareAPIKey: "test",
+		},
+	}
+	ctx := context.Background()
+
+	err := worker.Work(ctx, &river.Job[jobs.ValidateCustomDomainArgs]{Args: jobs.ValidateCustomDomainArgs{
+		CustomDomainID: "test",
+	}})
+
+	require.NoError(t, err)
+}

--- a/test/create_custom_domain/main.go
+++ b/test/create_custom_domain/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/theopenlane/riverboat/pkg/jobs"
+	"github.com/theopenlane/riverboat/test/common"
+)
+
+// the main function here will insert a create_custom_domain job into the river
+// this will be picked up by the river server and processed
+func main() {
+	client := common.NewInsertOnlyRiverClient()
+
+	_, err := client.Insert(context.Background(), jobs.CreateCustomDomainArgs{
+		CustomDomainID: "test-domain-123",
+	}, nil)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error inserting create_custom_domain job")
+	}
+
+	log.Info().Msg("create_custom_domain job successfully inserted")
+}

--- a/test/delete_custom_domain/main.go
+++ b/test/delete_custom_domain/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/theopenlane/riverboat/pkg/jobs"
+	"github.com/theopenlane/riverboat/test/common"
+)
+
+// the main function here will insert a delete_custom_domain job into the river
+// this will be picked up by the river server and processed
+func main() {
+	client := common.NewInsertOnlyRiverClient()
+
+	_, err := client.Insert(context.Background(), jobs.DeleteCustomDomainArgs{
+		CustomDomainID: "test-domain-123",
+	}, nil)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error inserting delete_custom_domain job")
+	}
+
+	log.Info().Msg("delete_custom_domain job successfully inserted")
+}

--- a/test/validate_custom_domain/main.go
+++ b/test/validate_custom_domain/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/theopenlane/riverboat/pkg/jobs"
+	"github.com/theopenlane/riverboat/test/common"
+)
+
+// the main function here will insert a validate_custom_domain job into the river
+// this will be picked up by the river server and processed
+func main() {
+	client := common.NewInsertOnlyRiverClient()
+
+	_, err := client.Insert(context.Background(), jobs.ValidateCustomDomainArgs{
+		CustomDomainID: "test-domain-123",
+	}, nil)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error inserting validate_custom_domain job")
+	}
+
+	log.Info().Msg("validate_custom_domain job successfully inserted")
+}


### PR DESCRIPTION
Scaffolding for the CustomDomain jobs.

All unimplemented at the moment.

The create and delete jobs will be triggered from gql hooks, and the Validate job will run periodically, and can also be triggered with a single domain.
