### PR TITLE
set max attempts for email worker jobs to 2

### DIFF
--- a/configgen/api-docs.md
+++ b/configgen/api-docs.md
@@ -40,9 +40,9 @@ Workers that will be enabled on the server
 |----|----|-----------|--------|
 |[**emailWorker**](#riverworkersemailworker)|`object`|EmailWorker is a worker to send emails using the resend email provider the config defaults to dev mode, which will write the email to a file using the mock provider a token is required to send emails using the actual resend provider<br/>||
 |[**databaseWorker**](#riverworkersdatabaseworker)|`object`|DatabaseWorker is a worker to create a dedicated database for an organization<br/>||
-|[**createCustomDomainWorker**](#riverworkerscreatecustomdomainworker)|`object`|CreateCustomDomainWorker creates a custom hostname in cloudflare, and creates and updates the records in our system<br/>||
-|[**validateCustomDomainWorker**](#riverworkersvalidatecustomdomainworker)|`object`|ValidateCustomDomainWorker checks cloudflare custom domain(s), and updates the status in our system<br/>||
-|[**deleteCustomDomainWorker**](#riverworkersdeletecustomdomainworker)|`object`|DeleteCustomDomainWorker delete the custom hostname from cloudflare and updates the records in our system<br/>||
+|[**createCustomDomainWorker**](#riverworkerscreatecustomdomainworker)|`object`|||
+|[**validateCustomDomainWorker**](#riverworkersvalidatecustomdomainworker)|`object`|||
+|[**deleteCustomDomainWorker**](#riverworkersdeletecustomdomainworker)|`object`|||
 
 **Additional Properties:** not allowed  
 <a name="riverworkersemailworker"></a>
@@ -103,21 +103,15 @@ DatabaseWorker is a worker to create a dedicated database for an organization
 <a name="riverworkerscreatecustomdomainworker"></a>
 #### river\.workers\.createCustomDomainWorker: object
 
-CreateCustomDomainWorker creates a custom hostname in cloudflare, and creates and updates the records in our system
-
-
 **Properties**
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|[**Config**](#riverworkerscreatecustomdomainworkerconfig)|`object`|CustomDomainConfig contains the configuration for the custom domain workers<br/>||
+|[**Config**](#riverworkerscreatecustomdomainworkerconfig)|`object`|||
 
 **Additional Properties:** not allowed  
 <a name="riverworkerscreatecustomdomainworkerconfig"></a>
 ##### river\.workers\.createCustomDomainWorker\.Config: object
-
-CustomDomainConfig contains the configuration for the custom domain workers
-
 
 **Properties**
 
@@ -132,21 +126,15 @@ CustomDomainConfig contains the configuration for the custom domain workers
 <a name="riverworkersvalidatecustomdomainworker"></a>
 #### river\.workers\.validateCustomDomainWorker: object
 
-ValidateCustomDomainWorker checks cloudflare custom domain(s), and updates the status in our system
-
-
 **Properties**
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|[**Config**](#riverworkersvalidatecustomdomainworkerconfig)|`object`|CustomDomainConfig contains the configuration for the custom domain workers<br/>||
+|[**Config**](#riverworkersvalidatecustomdomainworkerconfig)|`object`|||
 
 **Additional Properties:** not allowed  
 <a name="riverworkersvalidatecustomdomainworkerconfig"></a>
 ##### river\.workers\.validateCustomDomainWorker\.Config: object
-
-CustomDomainConfig contains the configuration for the custom domain workers
-
 
 **Properties**
 
@@ -161,21 +149,15 @@ CustomDomainConfig contains the configuration for the custom domain workers
 <a name="riverworkersdeletecustomdomainworker"></a>
 #### river\.workers\.deleteCustomDomainWorker: object
 
-DeleteCustomDomainWorker delete the custom hostname from cloudflare and updates the records in our system
-
-
 **Properties**
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|[**Config**](#riverworkersdeletecustomdomainworkerconfig)|`object`|CustomDomainConfig contains the configuration for the custom domain workers<br/>||
+|[**Config**](#riverworkersdeletecustomdomainworkerconfig)|`object`|||
 
 **Additional Properties:** not allowed  
 <a name="riverworkersdeletecustomdomainworkerconfig"></a>
 ##### river\.workers\.deleteCustomDomainWorker\.Config: object
-
-CustomDomainConfig contains the configuration for the custom domain workers
-
 
 **Properties**
 

--- a/configgen/generator.go
+++ b/configgen/generator.go
@@ -30,7 +30,7 @@ const (
 	yamlConfigPath = "./config/config.example.yaml"
 	envConfigPath  = "./config/.env.example"
 	configMapPath  = "./config/configmap.yaml"
-	ownerReadWrite = 0600
+	ownerReadWrite = 0o600
 	repoRoot       = "github.com/theopenlane/%s/"
 )
 

--- a/configgen/riverboat.config.json
+++ b/configgen/riverboat.config.json
@@ -8,6 +8,51 @@
       },
       "type": "array"
     },
+    "corejobs.CreateCustomDomainWorker": {
+      "properties": {
+        "Config": {
+          "$ref": "#/$defs/corejobs.CustomDomainConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "corejobs.CustomDomainConfig": {
+      "properties": {
+        "cloudflareApiKey": {
+          "type": "string"
+        },
+        "openlaneAPIHost": {
+          "type": "string"
+        },
+        "openlaneAPIToken": {
+          "type": "string"
+        },
+        "databaseHost": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "corejobs.DeleteCustomDomainWorker": {
+      "properties": {
+        "Config": {
+          "$ref": "#/$defs/corejobs.CustomDomainConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "corejobs.ValidateCustomDomainWorker": {
+      "properties": {
+        "Config": {
+          "$ref": "#/$defs/corejobs.CustomDomainConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "dbxclient.Config": {
       "properties": {
         "enabled": {
@@ -30,35 +75,6 @@
       "additionalProperties": false,
       "type": "object"
     },
-    "jobs.CreateCustomDomainWorker": {
-      "properties": {
-        "Config": {
-          "$ref": "#/$defs/jobs.CustomDomainConfig"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "CreateCustomDomainWorker creates a custom hostname in cloudflare, and creates and updates the records in our system"
-    },
-    "jobs.CustomDomainConfig": {
-      "properties": {
-        "cloudflareApiKey": {
-          "type": "string"
-        },
-        "openlaneAPIHost": {
-          "type": "string"
-        },
-        "openlaneAPIToken": {
-          "type": "string"
-        },
-        "databaseHost": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "CustomDomainConfig contains the configuration for the custom domain workers"
-    },
     "jobs.DatabaseWorker": {
       "properties": {
         "config": {
@@ -69,16 +85,6 @@
       "additionalProperties": false,
       "type": "object",
       "description": "DatabaseWorker is a worker to create a dedicated database for an organization"
-    },
-    "jobs.DeleteCustomDomainWorker": {
-      "properties": {
-        "Config": {
-          "$ref": "#/$defs/jobs.CustomDomainConfig"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "DeleteCustomDomainWorker delete the custom hostname from cloudflare and updates the records in our system"
     },
     "jobs.EmailConfig": {
       "properties": {
@@ -113,16 +119,6 @@
       "additionalProperties": false,
       "type": "object",
       "description": "EmailWorker is a worker to send emails using the resend email provider the config defaults to dev mode, which will write the email to a file using the mock provider a token is required to send emails using the actual resend provider"
-    },
-    "jobs.ValidateCustomDomainWorker": {
-      "properties": {
-        "Config": {
-          "$ref": "#/$defs/jobs.CustomDomainConfig"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "ValidateCustomDomainWorker checks cloudflare custom domain(s), and updates the status in our system"
     },
     "river.Config": {
       "properties": {
@@ -169,15 +165,15 @@
           "description": "DatabaseWorker configuration for creating databases using openlane/dbx"
         },
         "createCustomDomainWorker": {
-          "$ref": "#/$defs/jobs.CreateCustomDomainWorker",
+          "$ref": "#/$defs/corejobs.CreateCustomDomainWorker",
           "description": "CreateCustomDomainWorker configuration for creating custom domains"
         },
         "validateCustomDomainWorker": {
-          "$ref": "#/$defs/jobs.ValidateCustomDomainWorker",
+          "$ref": "#/$defs/corejobs.ValidateCustomDomainWorker",
           "description": "ValidateCustomDomainWorker configuration for validating custom domains"
         },
         "deleteCustomDomainWorker": {
-          "$ref": "#/$defs/jobs.DeleteCustomDomainWorker",
+          "$ref": "#/$defs/corejobs.DeleteCustomDomainWorker",
           "description": "DeleteCustomDomainWorker configuration for deleting custom domains"
         }
       },

--- a/pkg/jobs/email.go
+++ b/pkg/jobs/email.go
@@ -9,6 +9,10 @@ import (
 	"github.com/theopenlane/newman/providers/resend"
 )
 
+const (
+	maxEmailAttempts = 2
+)
+
 // EmailArgs for the email worker to process the job
 type EmailArgs struct {
 	// Message is the email message to send
@@ -20,9 +24,9 @@ func (EmailArgs) Kind() string { return "email" }
 
 // InsertOpts provides the default configuration when processing this job.
 // Here we want to retry sending an email a maxium of 3 times
-// This can be overriden on inserting the job
+// This can be overridden on inserting the job
 func (EmailArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{MaxAttempts: 2}
+	return river.InsertOpts{MaxAttempts: maxEmailAttempts}
 }
 
 // EmailWorker is a worker to send emails using the resend email provider

--- a/pkg/jobs/email.go
+++ b/pkg/jobs/email.go
@@ -18,6 +18,13 @@ type EmailArgs struct {
 // Kind satisfies the river.Job interface
 func (EmailArgs) Kind() string { return "email" }
 
+// InsertOpts provides the default configuration when processing this job.
+// Here we want to retry sending an email a maxium of 3 times
+// This can be overriden on inserting the job
+func (EmailArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{MaxAttempts: 2}
+}
+
 // EmailWorker is a worker to send emails using the resend email provider
 // the config defaults to dev mode, which will write the email to a file using the mock provider
 // a token is required to send emails using the actual resend provider


### PR DESCRIPTION
By default try to process an email job twice and no more than that. this can be configured and overriden in `core`  if need be