### PR TITLE
feat: add dev docker file that uses local built binary

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -77,6 +77,12 @@ tasks:
     cmds:
       - go build {{if .INCLUDE_TRUST_CENTER}}-tags=trustcenter{{end}} -o riverboat
 
+  go:build:linux:
+    desc: Runs go build for the riverboat server
+    silent: true
+    cmds:
+      - GOOS=linux go build {{if .INCLUDE_TRUST_CENTER}}-tags=trustcenter{{end}} -o riverboat
+
   go:build:ci:
     desc: Runs go build for the riverboat server
     silent: true

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+
+# Copy the binary
+COPY riverboat /bin/riverboat
+
+# Run the server on container startup
+ENTRYPOINT [ "/bin/riverboat" ]
+CMD ["serve"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,9 @@
 FROM ubuntu:22.04
 
+# add non-root user
+RUN useradd -u 1000 nonroot
+USER nonroot
+
 # Copy the binary
 COPY riverboat /bin/riverboat
 

--- a/docker/Taskfile.yaml
+++ b/docker/Taskfile.yaml
@@ -7,6 +7,14 @@ tasks:
     cmds:
       - "docker build -f docker/Dockerfile . -t riverboat:dev"
 
+  build:local:
+    dir: ..
+    desc: builds the riverboat docker image
+    deps:
+      - :go:build:linux
+    cmds:
+      - "docker build -f docker/Dockerfile.dev . -t riverboat:dev"
+
   riverboat:ui:up:
     dir: ..
     desc: runs the riverboat ui


### PR DESCRIPTION
Allows easier local dev for private modules to avoid having to pass git configs to the docker container to build, you can now just do to have a trust-center enabled build

```
INCLUDE_TRUST_CENTER=true task docker:build:local 
```